### PR TITLE
197 policy tab crash without model output

### DIFF
--- a/inst/ShinyFiles/MainApp/server.R
+++ b/inst/ShinyFiles/MainApp/server.R
@@ -7879,7 +7879,6 @@ server = function(input, output, session) {
     servr::daemon_stop()
   }) 
   
-  
   # policy -----
   
   ### create reactive data frame 
@@ -7887,44 +7886,17 @@ server = function(input, output, session) {
   clicked_ids <- reactiveValues(ids = vector())
   closures <- reactiveValues()
   rv <- reactiveValues(edit = NULL)
-  mod_zones <- reactiveValues(data = NULL)
-  
-  observeEvent(req(input$tabs == "Zone Closure"), {
-    tryCatch({
-      if(!is.null(model_out_view(project$name))){
-        mod_output <- unserialize_table(paste0(project$name,"ModelOut"), project$name)
-        mod_zones$data <- list()
-        mod_zones$data <- lapply(1:length(mod_output), function(x){rbind(mod_zones$data,unique(mod_output[[x]]$choice.table$choice))})
-        mod_zones$data <- unique(unlist(mod_zones$data))
-        
-      } else if(length(mod_zones$data) == 0){
-        showNotification("WARNING: no zones found in model output", type = "warning", duration = 60)
-        mod_zones$data <- NULL
-        
-      } else {
-        # do nothing
-        mod_zones$data <- NULL
-        
-      }
-    }, error = function(e){
-      showNotification(paste0("Model output table not found for project ", project$name), 
-                       type = "error", duration = 60)
-    })
-  })
-  
-  mod_reactive <- reactive({
-    mod_zones()
-  })
+
+  zone_closure_mapServer("policy", project = project$name, spatdat = spatdat$dataset, clicked_ids, V, closures, rv)
   
   zone_closure_sideServer("policy", project = project$name, spatdat = spatdat$dataset)
 
-  zone_closure_mapServer("policy", project = project$name, spatdat = spatdat$dataset, mod_zones = mod_reactive, clicked_ids, V, closures, rv)
-  
   zone_closure_tblServer("policy", project = project$name, spatdat = spatdat$dataset, clicked_ids, V)
   
-# run_policy ------
+  # run_policy ------
 
   pred_plotsServer("run_policy", project = project$name, spatdat = spatdat$dataset , values = values$dataset)
-  pred_mapServer("run_policy", project = project$name, spatdat = spatdat$dataset )
+  
+  pred_mapServer("run_policy", project = project$name, spatdat = spatdat$dataset)
 
 }

--- a/inst/ShinyFiles/MainApp/zone_closure_Server.R
+++ b/inst/ShinyFiles/MainApp/zone_closure_Server.R
@@ -26,7 +26,7 @@ zone_closure_mapServer <- function(id, project, spatdat, clicked_ids, V, closure
       ns <- session$ns
       
       mod_zones <- reactiveValues(data = NULL)
-
+      
       zone_df <- reactive({
         req(input$select_zone_cat)
         req(input$zoneplot)
@@ -66,12 +66,12 @@ zone_closure_mapServer <- function(id, project, spatdat, clicked_ids, V, closure
           showNotification(paste0("Model output table not found for project ", project),
                            type = "error", duration = 60)
         })
-    
+        
         # Check that mode_zones$data is not null
         if(is.null(mod_zones$data)){
           # I think do nothing here because this will be captured by the tryCatch above
           
-        # Check that zone ID selected is valid
+          # Check that zone ID selected is valid
         } else if(!(all(mod_zones$data %in% spatdat[[input$select_zone_cat]]))){ 
           showNotification("Invalid zone ID input. Could not find model output zones in selected variable.", 
                            type = "error", duration = 60)
@@ -194,16 +194,12 @@ zone_closure_mapServer <- function(id, project, spatdat, clicked_ids, V, closure
         req(input$scenarioname)
         req(pass)
         
-        #  close_nm <- if (input$mode == "normal") NULL else close_nm
-        
         closures$dList <- c(closures$dList,
                             list(c(list(scenario = input$scenarioname),
                                    list(date = as.character(Sys.Date())),
                                    list(zone = clicked_ids$ids),
                                    list(tac = V$data$`% allowable TAC`),
                                    list(grid_name = grid_nm)
-                                   # list(closure_name = add_close(NULL, input$mode)),
-                                   #  list(combined_areas = rv$combined_areas)
                             )))
       })
       
@@ -222,14 +218,14 @@ zone_closure_mapServer <- function(id, project, spatdat, clicked_ids, V, closure
       
       # save ----
       observeEvent(input$saveClose, {
-
+        
         if (!isTruthy(closures$dList)) {
           
           showNotification("Add a scenario", type = "error", duration = 60)
         }
         
         req(closures$dList)
- 
+        
         # update closure list w/ new grid names
         g_info <- get_grid_log(project)
         

--- a/inst/ShinyFiles/MainApp/zone_closure_Server.R
+++ b/inst/ShinyFiles/MainApp/zone_closure_Server.R
@@ -14,9 +14,6 @@ zone_closure_sideServer <- function(id, project, spatdat){
                     choices = unique(names(spatdat)))
         
       })
-      
-      
-      
     }
   )
 }
@@ -31,20 +28,15 @@ zone_closure_mapServer <- function(id, project, spatdat, clicked_ids, V, closure
       
       mod_zones <- reactiveValues(data = NULL)
       
-      
-      
       observeEvent(input$select_zone_cat, {
-        
 
         req(project)
-
 
         if(!is.null(model_out_view(project))){
           mod_output <- unserialize_table(paste0(project,"ModelOut"), project)
           mod_zones$data <- list()
           mod_zones$data <- lapply(1:length(mod_output), function(x){rbind(mod_zones$data,unique(mod_output[[x]]$choice.table$choice))})
           mod_zones$data <- unique(unlist(mod_zones$data))
-
 
         }else if(length(mod_zones$data) == 0){
           showNotification("WARNING: no zones found in model output", type = "warning", duration = 60)
@@ -54,9 +46,6 @@ zone_closure_mapServer <- function(id, project, spatdat, clicked_ids, V, closure
           mod_zones$data <- NULL
         }
         return(mod_zones$data)
-          
-       
-
       })
 
       zone_df <- reactive({
@@ -70,9 +59,6 @@ zone_closure_mapServer <- function(id, project, spatdat, clicked_ids, V, closure
         
       })
      
-      
-      
-      
 output$zmap <- leaflet::renderLeaflet({
   
   leaflet::leaflet() %>%
@@ -122,37 +108,19 @@ output$zmap <- leaflet::renderLeaflet({
           
           leaflet::leafletProxy(mapId = "zmap") %>%
             leaflet::addProviderTiles("OpenStreetMap") 
-          # leaflet::addPolygons(data = zone_df(),
-            #                      fillColor = "white",
-            #                      fillOpacity = 0.5,
-            #                      color = "black",
-            #                      stroke = TRUE,
-            #                      weight = 1,
-            #                      layerId = ~secondLocationID,
-            #                      group = "regions",
-            #                      label = ~secondLocationID)
         }
-        
-        
-        
       })
       
-   # })
-      
       observeEvent(input$zmap_shape_click, {
-        
-
+    
         # create object for clicked polygon
         click <- input$zmap_shape_click
         
         req(click$id)
         
-        
-        
         temp_dat <- zone_df()
         z_id <- "zone"
         sec_id <- "secondLocationID"
-        #  }
         
         #define leaflet proxy for second regional level map
         proxy <- leaflet::leafletProxy("zmap")

--- a/inst/ShinyFiles/MainApp/zone_closure_Server.R
+++ b/inst/ShinyFiles/MainApp/zone_closure_Server.R
@@ -121,8 +121,10 @@ zone_closure_mapServer <- function(id, project, spatdat, clicked_ids, V, closure
             leaflet::leafletProxy(mapId = "zmap") %>%
               leaflet::addProviderTiles("OpenStreetMap") 
           }
-          
         }
+        
+        # Updating the input helps by refreshing map if users click the plot zones button before running models
+        shiny::updateSelectInput(session, "select_zone_cat", selected = unique(names(spatdat))[1])
       })
       
       observeEvent(input$zmap_shape_click, {

--- a/inst/ShinyFiles/MainApp/zone_closure_Server.R
+++ b/inst/ShinyFiles/MainApp/zone_closure_Server.R
@@ -8,7 +8,6 @@ zone_closure_sideServer <- function(id, project, spatdat){
       
       ns <- session$ns
       
-      
       output$zone_closure_cat <- renderUI({
         selectInput(ns("select_zone_cat"), "Select zone ID from spatial data",
                     choices = unique(names(spatdat)))
@@ -29,7 +28,9 @@ zone_closure_mapServer <- function(id, project, spatdat, clicked_ids, V, closure
       mod_zones <- reactiveValues(data = NULL)
       
       observeEvent(input$select_zone_cat, {
-
+        
+        
+        
         req(project)
 
         if(!is.null(model_out_view(project))){
@@ -38,16 +39,19 @@ zone_closure_mapServer <- function(id, project, spatdat, clicked_ids, V, closure
           mod_zones$data <- lapply(1:length(mod_output), function(x){rbind(mod_zones$data,unique(mod_output[[x]]$choice.table$choice))})
           mod_zones$data <- unique(unlist(mod_zones$data))
 
-        }else if(length(mod_zones$data) == 0){
+        } else if(length(mod_zones$data) == 0){
           showNotification("WARNING: no zones found in model output", type = "warning", duration = 60)
           mod_zones$data <- NULL
+          
         } else {
           # do nothing
           mod_zones$data <- NULL
+          
         }
+        
         return(mod_zones$data)
       })
-
+      
       zone_df <- reactive({
         req(input$select_zone_cat)
         req(input$zoneplot)

--- a/inst/ShinyFiles/MainApp/zone_closure_Server.R
+++ b/inst/ShinyFiles/MainApp/zone_closure_Server.R
@@ -29,25 +29,30 @@ zone_closure_mapServer <- function(id, project, spatdat, clicked_ids, V, closure
       
       observeEvent(input$select_zone_cat, {
         
-        
-        
         req(project)
-
-        if(!is.null(model_out_view(project))){
-          mod_output <- unserialize_table(paste0(project,"ModelOut"), project)
-          mod_zones$data <- list()
-          mod_zones$data <- lapply(1:length(mod_output), function(x){rbind(mod_zones$data,unique(mod_output[[x]]$choice.table$choice))})
-          mod_zones$data <- unique(unlist(mod_zones$data))
-
-        } else if(length(mod_zones$data) == 0){
-          showNotification("WARNING: no zones found in model output", type = "warning", duration = 60)
-          mod_zones$data <- NULL
-          
-        } else {
-          # do nothing
-          mod_zones$data <- NULL
-          
-        }
+        
+        tryCatch({
+          if(!is.null(model_out_view(project))){
+            mod_output <- unserialize_table(paste0(project,"ModelOut"), project)
+            mod_zones$data <- list()
+            mod_zones$data <- lapply(1:length(mod_output), function(x){rbind(mod_zones$data,unique(mod_output[[x]]$choice.table$choice))})
+            mod_zones$data <- unique(unlist(mod_zones$data))
+            
+          } else if(length(mod_zones$data) == 0){
+            showNotification("WARNING: no zones found in model output", type = "warning", duration = 60)
+            mod_zones$data <- NULL
+            
+          } else {
+            # do nothing
+            mod_zones$data <- NULL
+            
+          }
+        }, error = function(e){
+          showNotification(paste0("Model output table not found for project ", project), 
+                           type = "error", duration = 60)
+        })
+        
+        
         
         return(mod_zones$data)
       })

--- a/inst/ShinyFiles/MainApp/zone_closure_UI.R
+++ b/inst/ShinyFiles/MainApp/zone_closure_UI.R
@@ -1,6 +1,5 @@
 # zone closure module UI code - sidebar, map, and table
 
-
 ### sidebar zone closure UI
 zone_closure_sidebarUI <- function(id){
   ns <- NS(id)
@@ -11,7 +10,6 @@ zone_closure_sidebarUI <- function(id){
     textInput(ns('scenarioname'), 'Scenario Name', value=''),
     actionButton(ns('addClose'), 'Add closure',
                  class = "btn-primary")
-    
   )
 }
 

--- a/inst/ShinyFiles/MainApp/zone_closure_UI.R
+++ b/inst/ShinyFiles/MainApp/zone_closure_UI.R
@@ -3,33 +3,32 @@
 
 ### sidebar zone closure UI
 zone_closure_sidebarUI <- function(id){
-     ns <- NS(id)
+  ns <- NS(id)
   tagList(
-       uiOutput(ns("zone_closure_cat")),
-      actionButton(ns('zoneplot'), "Plot zones",
+    uiOutput(ns("zone_closure_cat")),
+    actionButton(ns('zoneplot'), "Plot zones",
                  class = "btn-primary"),
-       textInput(ns('scenarioname'), 'Scenario Name', value=''),
-       actionButton(ns('addClose'), 'Add closure',
-                    class = "btn-primary")
-
-)
+    textInput(ns('scenarioname'), 'Scenario Name', value=''),
+    actionButton(ns('addClose'), 'Add closure',
+                 class = "btn-primary")
+    
+  )
 }
 
 ### map and selected points zone closure UI
 
 zone_closure_mapUI <- function(id){
   ns <- NS(id)
-
+  
   tagList(
-       bslib::card(
-       height = 650,
-       full_screen = TRUE,
-       shinycssloaders::withSpinner(
-     leaflet::leafletOutput(ns("zmap"), height = 600), 
-                                    type = 6)
-        )
- )
-     
+    bslib::card(
+      height = 650,
+      full_screen = TRUE,
+      shinycssloaders::withSpinner(
+        leaflet::leafletOutput(ns("zmap"), height = 600), 
+        type = 6)
+    )
+  )
 }
 
 ### table and closure viewer boxes zone closure UI


### PR DESCRIPTION
1. Opening the zone closure subtab no longer crashes the app
2. Moved some of the data processing in zone closure map server so the mod_zones reactive value updates once plot zones is clicked, instead of updating when a new input is selected for zone ID. The previous method wouldn't update key variables is some instances.