### PR TITLE
Upload primary data

### DIFF
--- a/FishSET.Rproj
+++ b/FishSET.Rproj
@@ -1,5 +1,4 @@
 Version: 1.0
-ProjectId: b62e2795-ac8e-4b9c-a6cd-42327758f1dc
 
 RestoreWorkspace: Default
 SaveWorkspace: Default

--- a/inst/ShinyFiles/MainApp/modules/load_files_server.R
+++ b/inst/ShinyFiles/MainApp/modules/load_files_server.R
@@ -102,15 +102,15 @@ select_project_server <- function(id, rv_folderpath){
 ## Load primary data ------------------------------------------------------------------------------
 ## Description: Provide user with a drop-down menu of primary tables if loading an existing 
 ##              project, but if this is a new project have the user upload a new file. Return the
-##              table name.
+##              table name and type of input.
 load_primary_server <- function(id, rv_project_name){
   moduleServer(id, function(input, output, session){
     # Observe project name reactive
     observeEvent(rv_project_name(), {
-      req(rv_project_name())
       project_name <- rv_project_name()
+      req(project_name)
       
-      # If running shiny tests - set existing project
+      # If running shiny tests - set primary table name
       if(getOption("shiny.testmode", FALSE)){ 
         shinyjs::show("primary_select_container") # Set shiny test table name
         shinyjs::hide("primary_upload_container")
@@ -120,7 +120,7 @@ load_primary_server <- function(id, rv_project_name){
         
         # Select an existing table
       } else if(project_name$type == "select" & !is.null(project_name$value)) {
-        shinyjs::show("primary_select_container") # Show dropdown menu of tables
+        shinyjs::show("primary_select_container") # Show dropdown menu of existing tables
         shinyjs::hide("primary_upload_container")
         primary_data_list <- list_tables(project_name$value, "main") # Get list of primary tables
         updateSelectInput(session, 
@@ -130,17 +130,15 @@ load_primary_server <- function(id, rv_project_name){
         # Upload a new file
       } else if (project_name$type == "text") {
         shinyjs::hide("primary_select_container")
-        shinyjs::show("primary_upload_container") # Show input for new file upload
+        shinyjs::show("primary_upload_container") # Show file input for uploading a new file
 
       }
     })
     
-    # Return the primary data table name
+    # Return the primary data table type (select existing or upload new file) and file/table name
     return(reactive({
       req(rv_project_name())
-      if(getOption("shiny.testmode", FALSE)){
-        list(type = "select", value = input$primary_select_input)
-      } else if(rv_project_name()$type == "select"){
+      if(rv_project_name()$type == "select"){
         list(type = "select", value = input$primary_select_input)
       } else {
         list(type = "upload", value = input$primary_upload_input)

--- a/inst/ShinyFiles/MainApp/modules/load_files_server.R
+++ b/inst/ShinyFiles/MainApp/modules/load_files_server.R
@@ -86,7 +86,7 @@ select_project_server <- function(id, rv_folderpath){
       }
     }, ignoreInit = FALSE) # Process this on initialization
     
-    # Return the current input value
+    # Return the project name
     return(reactive({
       if(getOption("shiny.testmode", FALSE)){
         list(type = "select", value = input$proj_select_input)
@@ -94,6 +94,44 @@ select_project_server <- function(id, rv_folderpath){
         list(type = "select", value = input$proj_select_input)
       } else {
         list(type = "text", value = input$proj_name_input)
+      }
+    }))
+  })
+}
+
+## Load primary data ------------------------------------------------------------------------------
+## Description: Provide user with a drop-down menu of primary tables if loading an existing 
+##              project, but if this is a new project have the user upload a new file. Return the
+##              table name.
+load_primary_server <- function(id, rv_project_name){
+  moduleServer(id, function(input, output, session){
+    # Observe project name reactive
+    observeEvent(rv_project_name(), {
+      req(rv_project_name())
+      project_name <- rv_project_name()
+      
+      # Select an existing table
+      if(project_name$type == "select" & !is.null(project_name$value)) {
+        primary_data_list <- list_tables(project_name$value, "main") # Get list of primary tables
+        shinyjs::show("primary_select_container") # Show dropdown menu of tables
+        shinyjs::hide("primary_upload_container")
+        updateSelectInput(session, "primary_select_input", choices = primary_data_list)
+        
+        # Upload a new file
+      } else if (project_name$type == "text") {
+        shinyjs::hide("primary_select_container")
+        shinyjs::show("primary_upload_container") # Show input for new file upload
+
+      }
+    })
+    
+    # Return the primary data table name
+    return(reactive({
+      req(rv_project_name())
+      if(rv_project_name()$type == "select"){
+        list(type = "select", value = input$primary_select_input)
+      } else {
+        list(type = "upload", value = input$primary_upload_input)
       }
     }))
   })

--- a/inst/ShinyFiles/MainApp/modules/load_files_server.R
+++ b/inst/ShinyFiles/MainApp/modules/load_files_server.R
@@ -112,7 +112,7 @@ load_primary_server <- function(id, rv_project_name){
       
       # If running shiny tests - set existing project
       if(getOption("shiny.testmode", FALSE)){ 
-        shinyjs::show("primary_select_container") # Show dropdown menu of tables
+        shinyjs::show("primary_select_container") # Set shiny test table name
         shinyjs::hide("primary_upload_container")
         updateSelectInput(session, 
                           "primary_select_input", 
@@ -123,7 +123,9 @@ load_primary_server <- function(id, rv_project_name){
         shinyjs::show("primary_select_container") # Show dropdown menu of tables
         shinyjs::hide("primary_upload_container")
         primary_data_list <- list_tables(project_name$value, "main") # Get list of primary tables
-        updateSelectInput(session, "primary_select_input", choices = primary_data_list)
+        updateSelectInput(session, 
+                          "primary_select_input", 
+                          choices = primary_data_list)
         
         # Upload a new file
       } else if (project_name$type == "text") {
@@ -136,7 +138,9 @@ load_primary_server <- function(id, rv_project_name){
     # Return the primary data table name
     return(reactive({
       req(rv_project_name())
-      if(rv_project_name()$type == "select"){
+      if(getOption("shiny.testmode", FALSE)){
+        list(type = "select", value = input$primary_select_input)
+      } else if(rv_project_name()$type == "select"){
         list(type = "select", value = input$primary_select_input)
       } else {
         list(type = "upload", value = input$primary_upload_input)

--- a/inst/ShinyFiles/MainApp/modules/load_files_server.R
+++ b/inst/ShinyFiles/MainApp/modules/load_files_server.R
@@ -110,11 +110,19 @@ load_primary_server <- function(id, rv_project_name){
       req(rv_project_name())
       project_name <- rv_project_name()
       
-      # Select an existing table
-      if(project_name$type == "select" & !is.null(project_name$value)) {
-        primary_data_list <- list_tables(project_name$value, "main") # Get list of primary tables
+      # If running shiny tests - set existing project
+      if(getOption("shiny.testmode", FALSE)){ 
         shinyjs::show("primary_select_container") # Show dropdown menu of tables
         shinyjs::hide("primary_upload_container")
+        updateSelectInput(session, 
+                          "primary_select_input", 
+                          choices = "scallop_shiny_testMainDataTable")
+        
+        # Select an existing table
+      } else if(project_name$type == "select" & !is.null(project_name$value)) {
+        shinyjs::show("primary_select_container") # Show dropdown menu of tables
+        shinyjs::hide("primary_upload_container")
+        primary_data_list <- list_tables(project_name$value, "main") # Get list of primary tables
         updateSelectInput(session, "primary_select_input", choices = primary_data_list)
         
         # Upload a new file

--- a/inst/ShinyFiles/MainApp/modules/load_files_ui.R
+++ b/inst/ShinyFiles/MainApp/modules/load_files_ui.R
@@ -70,7 +70,8 @@ load_primary_ui <- function(id){
       # select existing primary data table - initially hidden with CSS
       div(id = ns("primary_select_container"), 
           style = "display: none;",
-          selectInput(ns("primary_select_input"), "Choose primary data table", choices = NULL)),
+          selectInput(ns("primary_select_input"), "Choose primary data table", 
+                      choices = NULL)),
       
       # load new primary data file - initially visible
       div(id = ns("primary_upload_container"),

--- a/inst/ShinyFiles/MainApp/modules/load_files_ui.R
+++ b/inst/ShinyFiles/MainApp/modules/load_files_ui.R
@@ -48,7 +48,8 @@ select_project_ui <- function(id){
       
       column(9,
              # select project container - initially hidden with CSS
-             div(id = ns("proj_select_container"), style = "display: none;",
+             div(id = ns("proj_select_container"), 
+                 style = "display: none;",
                  selectInput(ns("proj_select_input"), "Choose a project", choices = NULL)),
              
              # project name input container - initially visible
@@ -60,13 +61,23 @@ select_project_ui <- function(id){
 }
 
 ## Load primary data ------------------------------------------------------------------------------
-## Description: 
-##
+## Description: Provide user with a dropdown menu of primary tables if loading an existing 
+##              project, but if this is a new project have the user upload a new file.
 load_primary_ui <- function(id){
   ns <- NS(id)
   tagList(
     fluidRow(
+      # select existing primary data table - initially hidden with CSS
+      div(id = ns("primary_select_container"), 
+          style = "display: none;",
+          selectInput(ns("primary_select_input"), "Choose primary data table", choices = NULL)),
       
+      # load new primary data file - initially visible
+      div(id = ns("primary_upload_container"),
+          fileInput(ns("primary_upload_input"), 
+                    "Choose primary data file", 
+                    multiple= FALSE,
+                    placeholder = "No file selected"))
     )
   )
 }

--- a/inst/ShinyFiles/MainApp/modules/load_files_ui.R
+++ b/inst/ShinyFiles/MainApp/modules/load_files_ui.R
@@ -76,7 +76,7 @@ load_primary_ui <- function(id){
       div(id = ns("primary_upload_container"),
           fileInput(ns("primary_upload_input"), 
                     "Choose primary data file", 
-                    multiple= FALSE,
+                    multiple = FALSE,
                     placeholder = "No file selected"))
     )
   )

--- a/inst/ShinyFiles/MainApp/server.R
+++ b/inst/ShinyFiles/MainApp/server.R
@@ -47,5 +47,4 @@ server <- function(input, output, session) {
   
   ### Load primary data
   rv_primary_data_name <- load_primary_server("load_primary", rv_project_name = rv_project_name)
-  
 }

--- a/inst/ShinyFiles/MainApp/server.R
+++ b/inst/ShinyFiles/MainApp/server.R
@@ -30,10 +30,8 @@ server <- function(input, output, session) {
   # Define reactives ------------------------------------------------------------------------------
   # Allow users to change FishSET folders easily.
   rv_folderpath <- reactiveVal({
-    if (fs_folder_exist) get("folderpath", 
-                             envir = as.environment(1L))
+    if (fs_folder_exist) get("folderpath", envir = as.environment(1L))
   })
-  
   rv_project_name <- reactiveVal() # Project name
   rv_primary_data_name <- reactiveVal() # Primary data name
   

--- a/inst/ShinyFiles/MainApp/server.R
+++ b/inst/ShinyFiles/MainApp/server.R
@@ -34,9 +34,9 @@ server <- function(input, output, session) {
                              envir = as.environment(1L))
   })
   
-  # Project name
-  rv_project_name <- reactiveVal()
-
+  rv_project_name <- reactiveVal() # Project name
+  rv_primary_data_name <- reactiveVal() # Primary data name
+  
   # Upload data -----------------------------------------------------------------------------------
   ## Load files subtab ----------------------------------------------------------------------------
   ### Change folderpath
@@ -44,4 +44,8 @@ server <- function(input, output, session) {
   
   ### Select project name
   rv_project_name <- select_project_server("select_project", rv_folderpath = rv_folderpath)
+  
+  ### Load primary data
+  rv_primary_data_name <- load_primary_server("load_primary", rv_project_name = rv_project_name)
+  
 }

--- a/inst/ShinyFiles/MainApp/ui.R
+++ b/inst/ShinyFiles/MainApp/ui.R
@@ -47,6 +47,7 @@ ui <- function(request){
               fill = TRUE, 
               width = 400
               
+              
             ),
             
             ### Change folder path

--- a/inst/ShinyFiles/MainApp/ui.R
+++ b/inst/ShinyFiles/MainApp/ui.R
@@ -74,7 +74,9 @@ ui <- function(request){
               bslib::card(fill = FALSE,
                           bslib::card_header("3. Primary data"),
                           bslib::card_body(
-                            load_primary_ui("load_primary")
+                            bslib::card(
+                              load_primary_ui("load_primary")  
+                            )
                           )
               ),
               


### PR DESCRIPTION
Modules for uploading the primary data are completed and shiny test code has been integrated. Shiny test script hardcodes the primary data table name - I think this is necessary because the functions that locate and grab existing tables hasn't been integrated with testthat.

I only did the primary table here to keep the review short and easy. I'll do the port data and auxiliary data uploads as separate PRs.

This is linked to #243 