### PR TITLE
Generalized select data module

### DIFF
--- a/inst/ShinyFiles/MainApp/modules/load_files_server.R
+++ b/inst/ShinyFiles/MainApp/modules/load_files_server.R
@@ -110,7 +110,7 @@ select_project_server <- function(id, rv_folderpath){
 ##              and type of input.
 select_data_server <- function(id, data_type, rv_project_name){
   moduleServer(id, function(input, output, session){
-    rv_out_type <- reactiveVal() # indicates which input value to return
+    rv_input_type <- reactiveVal() # indicates which input value to return
     
     # Observer project name reactive
     observeEvent(rv_project_name(), {
@@ -132,7 +132,7 @@ select_data_server <- function(id, data_type, rv_project_name){
         updateSelectInput(session, # Update option to the test table name 
                           paste0(data_type, "_select_input"), 
                           choices = shiny_test_table)
-        rv_out_type("select")
+        rv_input_type("select")
         
         # Select an existing table
       } else if(project_name$type == "select" & !is.null(project_name$value)) {
@@ -142,7 +142,7 @@ select_data_server <- function(id, data_type, rv_project_name){
         if(all(is_empty(data_table_list))){
           shinyjs::hide(paste0(data_type, "_select_container"))
           shinyjs::show(paste0(data_type, "_upload_container")) # Show file input
-          rv_out_type("upload")
+          rv_input_type("upload")
           
         } else {
           shinyjs::show(paste0(data_type, "_select_container")) # Show dropdown menu
@@ -151,14 +151,14 @@ select_data_server <- function(id, data_type, rv_project_name){
           updateSelectInput(session, 
                             paste0(data_type, "_select_input"),
                             choices = data_table_list)  # Populate choices
-          rv_out_type("select")
+          rv_input_type("select")
         }
         
         # Upload a new file
       } else if (project_name$type == "text") {
         shinyjs::hide(paste0(data_type, "_select_container"))
         shinyjs::show(paste0(data_type, "_upload_container")) # Show file input
-        rv_out_type("upload")
+        rv_input_type("upload")
       }
     })
     
@@ -169,12 +169,12 @@ select_data_server <- function(id, data_type, rv_project_name){
         if (input$spat_shp_chk_input == FALSE) {
           shinyjs::show("spat_file_container")  # Show single file upload
           shinyjs::hide("spat_shp_container")
-          rv_out_type("spat_file")
+          rv_input_type("spat_file")
           
         } else if (input$spat_shp_chk_input == TRUE) {
           shinyjs::show("spat_shp_container")   # Show shapefile uploader
           shinyjs::hide("spat_file_container")
-          rv_out_type("spat_shp")
+          rv_input_type("spat_shp")
           
         }  
       }
@@ -183,16 +183,16 @@ select_data_server <- function(id, data_type, rv_project_name){
     # Return the data table type (select existing or upload new file) and file/table name
     return(reactive({
       req(rv_project_name())
-      if(rv_out_type() == "select"){
+      if(rv_input_type() == "select"){
         list(type = "select", value = input[[paste0(data_type, "_select_input")]])
         
-      } else if(rv_out_type() == "upload"){
+      } else if(rv_input_type() == "upload"){
         list(type = "upload", value = input[[paste0(data_type, "_upload_input")]])
         
-      } else if(rv_out_type() == "spat_file"){
+      } else if(rv_input_type() == "spat_file"){
         list(type = "upload", value = input$spat_file_input)
         
-      } else if(rv_out_type() == "spat_shp"){
+      } else if(rv_input_type() == "spat_shp"){
         list(type = "upload", value = input$spat_shp_input)  
       }
     }))

--- a/inst/ShinyFiles/MainApp/modules/load_files_server.R
+++ b/inst/ShinyFiles/MainApp/modules/load_files_server.R
@@ -110,6 +110,8 @@ select_project_server <- function(id, rv_folderpath){
 ##              and type of input.
 select_data_server <- function(id, data_type, rv_project_name){
   moduleServer(id, function(input, output, session){
+    rv_out_type <- reactiveVal() # indicate which value to output
+    
     # Observer project name reactive
     observeEvent(rv_project_name(), {
       req(rv_project_name()) # Check to ensure reactive is available
@@ -130,6 +132,7 @@ select_data_server <- function(id, data_type, rv_project_name){
         updateSelectInput(session, # Update option to the test table name 
                           paste0(data_type, "_select_input"), 
                           choices = shiny_test_table)
+        rv_out_type("select")
         
         # Select an existing table
       } else if(project_name$type == "select" & !is.null(project_name$value)) {
@@ -139,6 +142,8 @@ select_data_server <- function(id, data_type, rv_project_name){
         if(all(is_empty(data_table_list))){
           shinyjs::hide(paste0(data_type, "_select_container"))
           shinyjs::show(paste0(data_type, "_upload_container")) # Show file input
+          rv_out_type("upload")
+          
         } else {
           shinyjs::show(paste0(data_type, "_select_container")) # Show dropdown menu
           shinyjs::hide(paste0(data_type, "_upload_container"))
@@ -146,13 +151,14 @@ select_data_server <- function(id, data_type, rv_project_name){
           updateSelectInput(session, 
                             paste0(data_type, "_select_input"),
                             choices = data_table_list)  # Populate choices
+          rv_out_type("select")
         }
         
         # Upload a new file
       } else if (project_name$type == "text") {
         shinyjs::hide(paste0(data_type, "_select_container"))
         shinyjs::show(paste0(data_type, "_upload_container")) # Show file input
-        
+        rv_out_type("upload")
       }
     })
     
@@ -163,10 +169,13 @@ select_data_server <- function(id, data_type, rv_project_name){
         if (input$spat_shp_chk_input == FALSE) {
           shinyjs::show("spat_file_container")  # Show single file upload
           shinyjs::hide("spat_shp_container")
+          rv_out_type("spat_file")
           
         } else if (input$spat_shp_chk_input == TRUE) {
           shinyjs::show("spat_shp_container")   # Show shapefile uploader
           shinyjs::hide("spat_file_container")
+          rv_out_type("spat_shp")
+          
         }  
       }
     })
@@ -174,18 +183,17 @@ select_data_server <- function(id, data_type, rv_project_name){
     # Return the data table type (select existing or upload new file) and file/table name
     return(reactive({
       req(rv_project_name())
-      if(rv_project_name()$type == "select"){
+      if(rv_out_type() == "select"){
         list(type = "select", value = input[[paste0(data_type, "_select_input")]])
         
-      } else if(rv_project_name()$type == "text" & data_type == "spat"){
-        if(input$spat_shp_chk_input == TRUE){
-          list(type = "upload", value = input$spat_shp_input)  
-        } else {
-          list(type = "upload", value = input$spat_file_input)  
-        }
-        
-      } else {
+      } else if(rv_out_type() == "upload"){
         list(type = "upload", value = input[[paste0(data_type, "_upload_input")]])
+        
+      } else if(rv_out_type() == "spat_file"){
+        list(type = "upload", value = input$spat_file_input)
+        
+      } else if(rv_out_type() == "spat_shp"){
+        list(type = "upload", value = input$spat_shp_input)  
       }
     }))
   })

--- a/inst/ShinyFiles/MainApp/modules/load_files_server.R
+++ b/inst/ShinyFiles/MainApp/modules/load_files_server.R
@@ -110,7 +110,7 @@ select_project_server <- function(id, rv_folderpath){
 ##              and type of input.
 select_data_server <- function(id, data_type, rv_project_name){
   moduleServer(id, function(input, output, session){
-    rv_out_type <- reactiveVal() # indicate which value to output
+    rv_out_type <- reactiveVal() # indicates which input value to return
     
     # Observer project name reactive
     observeEvent(rv_project_name(), {

--- a/inst/ShinyFiles/MainApp/modules/load_files_server.R
+++ b/inst/ShinyFiles/MainApp/modules/load_files_server.R
@@ -110,7 +110,7 @@ select_project_server <- function(id, rv_folderpath){
 ##              and type of input.
 select_data_server <- function(id, data_type, rv_project_name){
   moduleServer(id, function(input, output, session){
-    rv_input_type <- reactiveVal() # indicates which input value to return
+    rv_data_input_type <- reactiveVal() # indicates which input value to return
     
     # Observer project name reactive
     observeEvent(rv_project_name(), {
@@ -132,7 +132,7 @@ select_data_server <- function(id, data_type, rv_project_name){
         updateSelectInput(session, # Update option to the test table name 
                           paste0(data_type, "_select_input"), 
                           choices = shiny_test_table)
-        rv_input_type("select")
+        rv_data_input_type("select")
         
         # Select an existing table
       } else if(project_name$type == "select" & !is.null(project_name$value)) {
@@ -142,7 +142,7 @@ select_data_server <- function(id, data_type, rv_project_name){
         if(all(is_empty(data_table_list))){
           shinyjs::hide(paste0(data_type, "_select_container"))
           shinyjs::show(paste0(data_type, "_upload_container")) # Show file input
-          rv_input_type("upload")
+          rv_data_input_type("upload")
           
         } else {
           shinyjs::show(paste0(data_type, "_select_container")) # Show dropdown menu
@@ -151,14 +151,14 @@ select_data_server <- function(id, data_type, rv_project_name){
           updateSelectInput(session, 
                             paste0(data_type, "_select_input"),
                             choices = data_table_list)  # Populate choices
-          rv_input_type("select")
+          rv_data_input_type("select")
         }
         
         # Upload a new file
       } else if (project_name$type == "text") {
         shinyjs::hide(paste0(data_type, "_select_container"))
         shinyjs::show(paste0(data_type, "_upload_container")) # Show file input
-        rv_input_type("upload")
+        rv_data_input_type("upload")
       }
     })
     
@@ -169,12 +169,12 @@ select_data_server <- function(id, data_type, rv_project_name){
         if (input$spat_shp_chk_input == FALSE) {
           shinyjs::show("spat_file_container")  # Show single file upload
           shinyjs::hide("spat_shp_container")
-          rv_input_type("spat_file")
+          rv_data_input_type("spat_file")
           
         } else if (input$spat_shp_chk_input == TRUE) {
           shinyjs::show("spat_shp_container")   # Show shapefile uploader
           shinyjs::hide("spat_file_container")
-          rv_input_type("spat_shp")
+          rv_data_input_type("spat_shp")
           
         }  
       }
@@ -183,16 +183,16 @@ select_data_server <- function(id, data_type, rv_project_name){
     # Return the data table type (select existing or upload new file) and file/table name
     return(reactive({
       req(rv_project_name())
-      if(rv_input_type() == "select"){
+      if(rv_data_input_type() == "select"){
         list(type = "select", value = input[[paste0(data_type, "_select_input")]])
         
-      } else if(rv_input_type() == "upload"){
+      } else if(rv_data_input_type() == "upload"){
         list(type = "upload", value = input[[paste0(data_type, "_upload_input")]])
         
-      } else if(rv_input_type() == "spat_file"){
+      } else if(rv_data_input_type() == "spat_file"){
         list(type = "upload", value = input$spat_file_input)
         
-      } else if(rv_input_type() == "spat_shp"){
+      } else if(rv_data_input_type() == "spat_shp"){
         list(type = "upload", value = input$spat_shp_input)  
       }
     }))

--- a/inst/ShinyFiles/MainApp/modules/load_files_ui.R
+++ b/inst/ShinyFiles/MainApp/modules/load_files_ui.R
@@ -72,17 +72,13 @@ select_data_ui <- function(id, data_type){
       div(id = ns(paste0(data_type, "_select_container")), 
           style = "display: none;", # hide this input to start
           selectInput(inputId = ns(paste0(data_type, "_select_input")),
-                      label = switch(data_type,
-                                     "main" = HTML(paste0("Select main",
-                                                          " data table <b>(required)</b>:")),
-                                     "port" = HTML(paste0("Select port",
-                                                          " data table <b>(optional)</b>:")),
-                                     "aux" = HTML(paste0("Select auxiliary",
-                                                         " data table <b>(optional)</b>:")),
-                                     "spat" = HTML(paste0("Select spatial",
-                                                          " table <b>(required)</b>:")),
-                                     "grid" = HTML(paste0("Select gridded",
-                                                          " data table <b>(optional)</b>:"))),
+                      label = 
+                        switch(data_type,
+                               "main" = HTML("Select main data table <b>(required)</b>:"),
+                               "port" = HTML("Select port data table <b>(optional)</b>:"),
+                               "aux" = HTML("Select auxiliary data table <b>(optional)</b>:"),
+                               "spat" = HTML("Select spatial table <b>(required)</b>:"),
+                               "grid" = HTML("Select gridded data table <b>(optional)</b>:")),
                       choices = NULL)
       ),
       
@@ -90,15 +86,12 @@ select_data_ui <- function(id, data_type){
       if(data_type != "spat"){
         div(id = ns(paste0(data_type, "_upload_container")),
             fileInput(ns(paste0(data_type, "_upload_input")),
-                      label = switch(data_type,
-                                     "main" = HTML(paste0("Select main",
-                                                          " data file <b>(required)</b>:")),
-                                     "port" = HTML(paste0("Select port",
-                                                          " file <b>(optional)</b>:")),
-                                     "aux" = HTML(paste0("Select auxiliary",
-                                                         " data file <b>(optional)</b>:")),
-                                     "grid" = HTML(paste0("Select gridded",
-                                                          " data file <b>(optional)</b>:"))),
+                      label = 
+                        switch(data_type,
+                               "main" = HTML("Select main data file <b>(required)</b>:"),
+                               "port" = HTML("Select port file <b>(optional)</b>:"),
+                               "aux" = HTML("Select auxiliary data file <b>(optional)</b>:"),
+                               "grid" = HTML("Select gridded data file <b>(optional)</b>:")),
                       multiple = FALSE,
                       placeholder = "No file selected")
         )

--- a/inst/ShinyFiles/MainApp/modules/load_files_ui.R
+++ b/inst/ShinyFiles/MainApp/modules/load_files_ui.R
@@ -122,7 +122,6 @@ select_data_ui <- function(id, data_type){
                             accept = c('.shp', '.dbf', '.sbn', '.sbx', '.shx', '.prj', '.cpg'),
                             multiple = TRUE, 
                             placeholder = 'No file selected')
-                  
               ),
               
               #Checkbox to change file upload to shape files

--- a/inst/ShinyFiles/MainApp/modules/load_files_ui.R
+++ b/inst/ShinyFiles/MainApp/modules/load_files_ui.R
@@ -61,8 +61,9 @@ select_project_ui <- function(id){
 }
 
 ## Select data ------------------------------------------------------------------------------------
-## Description: Provide user with a dropdown menu of main (aka primary) tables if loading an 
-##              existing project, but if this is a new project have the user upload a new file.
+## Description: Provide user with a dropdown menu if loading an existing project AND the data 
+##              table exists in the project. Otherwise, give the user the file input option, and 
+##              include option to load shape files for spatial data.
 select_data_ui <- function(id, data_type){
   ns <- NS(id)
   tagList(
@@ -71,173 +72,62 @@ select_data_ui <- function(id, data_type){
       div(id = ns(paste0(data_type, "_select_container")), 
           style = "display: none;",
           selectInput(ns(paste0(data_type, "_select_input")),
-                      label = "main",
-                      # label = switch(data_type,
-                      #                "main" = HTML(paste0("Select main",
-                      #                                     " data table <b>(required)</b>:")),
-                      #                "port" = HTML(paste0("Select port",
-                      #                                     " data table <b>(optional)</b>:")),
-                      #                "aux" = HTML(paste0("Select auxiliary",  
-                      #                                    " data table <b>(optional)</b>:")),
-                      #                "grid" = HTML(paste0("Select gridded",  
-                      #                                     " data table <b>(optional)</b>:"))
-                      # ),
+                      label = switch(data_type,
+                                     "main" = HTML(paste0("Select main",
+                                                          " data table <b>(required)</b>:")),
+                                     "port" = HTML(paste0("Select port",
+                                                          " data table <b>(optional)</b>:")),
+                                     "aux" = HTML(paste0("Select auxiliary",
+                                                         " data table <b>(optional)</b>:")),
+                                     "spat" = HTML(paste0("Select spatial",
+                                                          " table <b>(optional)</b>:")),
+                                     "grid" = HTML(paste0("Select gridded",
+                                                          " data table <b>(optional)</b>:"))
+                      ),
                       choices = NULL)),
       
-      # select new data file - initially visible
-      div(id = ns(paste0(data_type, "_upload_container")),
-          fileInput(ns(paste0(data_type, "_upload_input")),
-                    label = "main",
-                    # label = switch(data_type,
-                    #                "main" = HTML(paste0("Select main", 
-                    #                                     " data file <b>(required)</b>:")),
-                    #                "port" = HTML(paste0("Select port", 
-                    #                                     " file <b>(optional)</b>:")),
-                    #                "aux" = HTML(paste0("Select auxiliary",  
-                    #                                    " data file <b>(optional)</b>:")),
-                    #                "grid" = HTML(paste0("Select gridded",  
-                    #                                     " data file <b>(optional)</b>:"))
-                    # ),
-                    multiple = FALSE,
-                    placeholder = "No file selected"))
-    )
-  )
-}
-
-## Select main data -------------------------------------------------------------------------------
-## Description: Provide user with a dropdown menu of main (aka primary) tables if loading an 
-##              existing project, but if this is a new project have the user upload a new file.
-select_main_ui <- function(id){
-  ns <- NS(id)
-  tagList(
-    fluidRow(
-      # select existing main data table - initially hidden with CSS
-      div(id = ns("main_select_container"), 
-          style = "display: none;",
-          selectInput(ns("main_select_input"),
-                      label = HTML("Select main data table <b>(required)</b>:"),
-                      choices = NULL)),
-      
-      # select new main data file - initially visible
-      div(id = ns("main_upload_container"),
-          fileInput(ns("main_upload_input"), 
-                    label = HTML("Select main data file <b>(required)</b>:"),
-                    multiple = FALSE,
-                    placeholder = "No file selected"))
-    )
-  )
-}
-
-## Select port data -------------------------------------------------------------------------------
-## Description: Provide user with a dropdown menu of port tables if loading an existing 
-##              project, but if this is a new project have the user upload a new file.
-select_port_ui <- function(id){
-  ns <- NS(id)
-  tagList(
-    fluidRow(
-      # select existing port data table - initially hidden with CSS
-      div(id = ns("port_select_container"), 
-          style = "display: none;",
-          selectInput(ns("port_select_input"), 
-                      label = HTML("Select port data table <b>(optional)</b>:"),
-                      choices = NULL)),
-      
-      # load new port data file - initially visible
-      div(id = ns("port_upload_container"),
-          fileInput(ns("port_upload_input"), 
-                    label = HTML("Select port data file <b>(optional)</b>:"),
-                    multiple = FALSE,
-                    placeholder = "No file selected"))
-    )
-  )
-}
-
-## Select aux data --------------------------------------------------------------------------------
-## Description: Provide user with a dropdown menu of aux tables if loading an existing project and
-##              table exists, but if this is a new project have the user upload a new file.
-select_aux_ui <- function(id){
-  ns <- NS(id)
-  tagList(
-    fluidRow(
-      # select existing aux data table - initially hidden with CSS
-      div(id = ns("aux_select_container"), 
-          style = "display: none;",
-          selectInput(ns("aux_select_input"), 
-                      label = HTML("Select auxiliary data table <b>(optional)</b>:"),
-                      choices = NULL)),
-      
-      # load new aux data file - initially visible
-      div(id = ns("aux_upload_container"),
-          fileInput(ns("aux_upload_input"), 
-                    label = HTML("Select auxiliary data file <b>(optional)</b>:"),
-                    multiple = FALSE,
-                    placeholder = "No file selected"))
-    )
-  )
-}
-
-## Select spatial data ----------------------------------------------------------------------------
-## Description: UI module function for spatial data upload and selection. Initially show file
-##              input, but if the user selects existing project show existing spatial tables.
-select_spatial_ui <- function(id){
-  ns <- NS(id)  
-  tagList(
-    # Hidden container for selecting an already uploaded spatial table
-    div(id = ns("spat_select_container"), style = "display: none;",
-        selectInput(ns("spat_select_input"), 
-                    label = HTML("Select spatial table <b>(required)</b>:"),
-                    choices = NULL)  # Choices will be populated dynamically
-    ),
-    
-    # Visible container for uploading spatial data
-    div(id = ns("spat_upload_container"),
-        fluidRow(
-          # File input for general spatial data files (e.g., CSV, GeoJSON)
-          div(id = ns('spat_file_container'), 
-              fileInput(ns("spat_file_input"), 
-                        label = HTML("Select spatial file <b>(required)</b>:"),
-                        multiple = FALSE, 
-                        placeholder = 'No file selected')
-          ),
-          # File input for shapefile components
-          div(id = ns("spat_shp_container"),
-              fileInput(ns("spat_shp_input"), 
-                        label = HTML("Select shape files <b>(required)</b>:"),
-                        accept = c('.shp', '.dbf', '.sbn', '.sbx', '.shx', '.prj', '.cpg'),
-                        multiple = TRUE, 
-                        placeholder = 'No file selected')
-              
-          ), 
-          #Checkbox to change file upload to shape files
-          checkboxInput(inputId = ns("spat_shp_chk_input"),
-                        label = "Uploading shape file instead?",
-                        value = FALSE)),
-    )
-  )
-}
-
-## Select gridded data ----------------------------------------------------------------------------
-## Description: UI module for uploading or selecting gridded (1D/2D) data. Initially show file
-##              input, but if user selects an existing project show existing gridded tables.
-select_grid_ui <- function(id){
-  ns <- NS(id)  
-  tagList(
-    # Hidden container to select a previously uploaded gridded table
-    div(id = ns("grid_select_container"), style = "display: none;",
-        selectInput(ns("grid_select_input"), 
-                    label = HTML("Select gridded table <b>(optional)</b>:"),
-                    choices = NULL)  # Choices will be populated dynamically
-    ),
-    # Visible container for uploading gridded data
-    div(id = ns("grid_upload_container"),
-        fluidRow(
-          # File input for uploading a single data file (e.g., CSV, TSV)
-          fileInput(ns("grid_file_input"), 
-                    label = HTML("Select gridded file <b>(optional)</b>:"),
-                    multiple = FALSE, 
-                    placeholder = 'No file selected')
+      if(data_type != "spat"){
+        # select new data file - initially visible
+        div(id = ns(paste0(data_type, "_upload_container")),
+            fileInput(ns(paste0(data_type, "_upload_input")),
+                      label = switch(data_type,
+                                     "main" = HTML(paste0("Select main",
+                                                          " data file <b>(required)</b>:")),
+                                     "port" = HTML(paste0("Select port",
+                                                          " file <b>(optional)</b>:")),
+                                     "aux" = HTML(paste0("Select auxiliary",
+                                                         " data file <b>(optional)</b>:")),
+                                     "grid" = HTML(paste0("Select gridded",
+                                                          " data file <b>(optional)</b>:"))
+                      ),
+                      multiple = FALSE,
+                      placeholder = "No file selected"))  
+      } else {
+        # Visible container for uploading spatial data
+        div(id = ns("spat_upload_container"),
+            fluidRow(
+              # File input for general spatial data files (e.g., CSV, GeoJSON)
+              div(id = ns('spat_upload_container'), 
+                  fileInput(ns("spat_upload_input"), 
+                            label = HTML("Select spatial file <b>(required)</b>:"),
+                            multiple = FALSE, 
+                            placeholder = 'No file selected')
+              ),
+              # File input for shapefile components
+              div(id = ns("spat_shp_container"),
+                  fileInput(ns("spat_shp_input"), 
+                            label = HTML("Select shape files <b>(required)</b>:"),
+                            accept = c('.shp', '.dbf', '.sbn', '.sbx', '.shx', '.prj', '.cpg'),
+                            multiple = TRUE, 
+                            placeholder = 'No file selected')
+                  
+              ), 
+              #Checkbox to change file upload to shape files
+              checkboxInput(inputId = ns("spat_shp_chk_input"),
+                            label = "Uploading shape file instead?",
+                            value = FALSE)),
         )
-        
+      }
     )
   )
 }

--- a/inst/ShinyFiles/MainApp/modules/load_files_ui.R
+++ b/inst/ShinyFiles/MainApp/modules/load_files_ui.R
@@ -70,8 +70,8 @@ select_data_ui <- function(id, data_type){
     fluidRow(
       # select existing data table - initially hidden with CSS
       div(id = ns(paste0(data_type, "_select_container")), 
-          style = "display: none;",
-          selectInput(ns(paste0(data_type, "_select_input")),
+          style = "display: none;", # hide this input to start
+          selectInput(inputId = ns(paste0(data_type, "_select_input")),
                       label = switch(data_type,
                                      "main" = HTML(paste0("Select main",
                                                           " data table <b>(required)</b>:")),
@@ -80,14 +80,14 @@ select_data_ui <- function(id, data_type){
                                      "aux" = HTML(paste0("Select auxiliary",
                                                          " data table <b>(optional)</b>:")),
                                      "spat" = HTML(paste0("Select spatial",
-                                                          " table <b>(optional)</b>:")),
+                                                          " table <b>(required)</b>:")),
                                      "grid" = HTML(paste0("Select gridded",
-                                                          " data table <b>(optional)</b>:"))
-                      ),
-                      choices = NULL)),
+                                                          " data table <b>(optional)</b>:"))),
+                      choices = NULL)
+      ),
       
+      # select new data file - initially visible
       if(data_type != "spat"){
-        # select new data file - initially visible
         div(id = ns(paste0(data_type, "_upload_container")),
             fileInput(ns(paste0(data_type, "_upload_input")),
                       label = switch(data_type,
@@ -98,21 +98,23 @@ select_data_ui <- function(id, data_type){
                                      "aux" = HTML(paste0("Select auxiliary",
                                                          " data file <b>(optional)</b>:")),
                                      "grid" = HTML(paste0("Select gridded",
-                                                          " data file <b>(optional)</b>:"))
-                      ),
+                                                          " data file <b>(optional)</b>:"))),
                       multiple = FALSE,
-                      placeholder = "No file selected"))  
+                      placeholder = "No file selected")
+        )
+        
       } else {
-        # Visible container for uploading spatial data
+        # Visible container for selecting spatial file(s)
         div(id = ns("spat_upload_container"),
             fluidRow(
               # File input for general spatial data files (e.g., CSV, GeoJSON)
-              div(id = ns('spat_upload_container'), 
-                  fileInput(ns("spat_upload_input"), 
+              div(id = ns('spat_file_container'), 
+                  fileInput(ns("spat_file_input"), 
                             label = HTML("Select spatial file <b>(required)</b>:"),
                             multiple = FALSE, 
                             placeholder = 'No file selected')
               ),
+              
               # File input for shapefile components
               div(id = ns("spat_shp_container"),
                   fileInput(ns("spat_shp_input"), 
@@ -121,7 +123,8 @@ select_data_ui <- function(id, data_type){
                             multiple = TRUE, 
                             placeholder = 'No file selected')
                   
-              ), 
+              ),
+              
               #Checkbox to change file upload to shape files
               checkboxInput(inputId = ns("spat_shp_chk_input"),
                             label = "Uploading shape file instead?",

--- a/inst/ShinyFiles/MainApp/modules/load_files_ui.R
+++ b/inst/ShinyFiles/MainApp/modules/load_files_ui.R
@@ -60,24 +60,68 @@ select_project_ui <- function(id){
   )
 }
 
-## Select primary data ----------------------------------------------------------------------------
-## Description: Provide user with a dropdown menu of primary tables if loading an existing 
-##              project, but if this is a new project have the user upload a new file.
-select_primary_ui <- function(id){
+## Select data ------------------------------------------------------------------------------------
+## Description: Provide user with a dropdown menu of main (aka primary) tables if loading an 
+##              existing project, but if this is a new project have the user upload a new file.
+select_data_ui <- function(id, data_type){
   ns <- NS(id)
   tagList(
     fluidRow(
-      # select existing primary data table - initially hidden with CSS
-      div(id = ns("primary_select_container"), 
+      # select existing data table - initially hidden with CSS
+      div(id = ns(paste0(data_type, "_select_container")), 
           style = "display: none;",
-          selectInput(ns("primary_select_input"),
-                      label = HTML("Select primary data table <b>(required)</b>:"),
+          selectInput(ns(paste0(data_type, "_select_input")),
+                      label = "main",
+                      # label = switch(data_type,
+                      #                "main" = HTML(paste0("Select main",
+                      #                                     " data table <b>(required)</b>:")),
+                      #                "port" = HTML(paste0("Select port",
+                      #                                     " data table <b>(optional)</b>:")),
+                      #                "aux" = HTML(paste0("Select auxiliary",  
+                      #                                    " data table <b>(optional)</b>:")),
+                      #                "grid" = HTML(paste0("Select gridded",  
+                      #                                     " data table <b>(optional)</b>:"))
+                      # ),
                       choices = NULL)),
       
-      # select new primary data file - initially visible
-      div(id = ns("primary_upload_container"),
-          fileInput(ns("primary_upload_input"), 
-                    label = HTML("Select primary data file <b>(required)</b>:"),
+      # select new data file - initially visible
+      div(id = ns(paste0(data_type, "_upload_container")),
+          fileInput(ns(paste0(data_type, "_upload_input")),
+                    label = "main",
+                    # label = switch(data_type,
+                    #                "main" = HTML(paste0("Select main", 
+                    #                                     " data file <b>(required)</b>:")),
+                    #                "port" = HTML(paste0("Select port", 
+                    #                                     " file <b>(optional)</b>:")),
+                    #                "aux" = HTML(paste0("Select auxiliary",  
+                    #                                    " data file <b>(optional)</b>:")),
+                    #                "grid" = HTML(paste0("Select gridded",  
+                    #                                     " data file <b>(optional)</b>:"))
+                    # ),
+                    multiple = FALSE,
+                    placeholder = "No file selected"))
+    )
+  )
+}
+
+## Select main data -------------------------------------------------------------------------------
+## Description: Provide user with a dropdown menu of main (aka primary) tables if loading an 
+##              existing project, but if this is a new project have the user upload a new file.
+select_main_ui <- function(id){
+  ns <- NS(id)
+  tagList(
+    fluidRow(
+      # select existing main data table - initially hidden with CSS
+      div(id = ns("main_select_container"), 
+          style = "display: none;",
+          selectInput(ns("main_select_input"),
+                      label = HTML("Select main data table <b>(required)</b>:"),
+                      choices = NULL)),
+      
+      # select new main data file - initially visible
+      div(id = ns("main_upload_container"),
+          fileInput(ns("main_upload_input"), 
+                    label = HTML("Select main data file <b>(required)</b>:"),
                     multiple = FALSE,
                     placeholder = "No file selected"))
     )
@@ -102,6 +146,30 @@ select_port_ui <- function(id){
       div(id = ns("port_upload_container"),
           fileInput(ns("port_upload_input"), 
                     label = HTML("Select port data file <b>(optional)</b>:"),
+                    multiple = FALSE,
+                    placeholder = "No file selected"))
+    )
+  )
+}
+
+## Select aux data --------------------------------------------------------------------------------
+## Description: Provide user with a dropdown menu of aux tables if loading an existing project and
+##              table exists, but if this is a new project have the user upload a new file.
+select_aux_ui <- function(id){
+  ns <- NS(id)
+  tagList(
+    fluidRow(
+      # select existing aux data table - initially hidden with CSS
+      div(id = ns("aux_select_container"), 
+          style = "display: none;",
+          selectInput(ns("aux_select_input"), 
+                      label = HTML("Select auxiliary data table <b>(optional)</b>:"),
+                      choices = NULL)),
+      
+      # load new aux data file - initially visible
+      div(id = ns("aux_upload_container"),
+          fileInput(ns("aux_upload_input"), 
+                    label = HTML("Select auxiliary data file <b>(optional)</b>:"),
                     multiple = FALSE,
                     placeholder = "No file selected"))
     )

--- a/inst/ShinyFiles/MainApp/server.R
+++ b/inst/ShinyFiles/MainApp/server.R
@@ -57,7 +57,7 @@ server <- function(input, output, session) {
                                           rv_project_name = rv_project_name)
   
   ### Select spatial data
-  rv_data_names$spatial <- select_data_server("select_spatial",
+  rv_data_names$spat <- select_data_server("select_spatial",
                                               data_type = "spat",
                                               rv_project_name = rv_project_name)
   
@@ -65,4 +65,34 @@ server <- function(input, output, session) {
   rv_data_names$grid <- select_data_server("select_grid",
                                            data_type = "grid",
                                            rv_project_name = rv_project_name)
+  
+  ##### TEST CODE #####
+  count <- reactiveVal(0)
+  
+  observeEvent(input$test_btn,{
+    new_count <- count() + 1
+    count(new_count)
+    cat(file=stderr(), "\n", new_count, "\n")
+    
+    output$display_main <- renderPrint(
+      str(rv_data_names$main())
+    )
+    
+    output$display_port <- renderPrint(
+      str(rv_data_names$port())
+    )
+    
+    output$display_aux <- renderPrint(
+      str(rv_data_names$aux())
+    )
+    
+    output$display_spat <- renderPrint(
+      str(rv_data_names$spat())
+    )
+    
+    output$display_grid <- renderPrint(
+      str(rv_data_names$grid())
+    )
+  })
+  #####################
 }

--- a/inst/ShinyFiles/MainApp/server.R
+++ b/inst/ShinyFiles/MainApp/server.R
@@ -58,41 +58,11 @@ server <- function(input, output, session) {
   
   ### Select spatial data
   rv_data_names$spat <- select_data_server("select_spatial",
-                                              data_type = "spat",
-                                              rv_project_name = rv_project_name)
+                                           data_type = "spat",
+                                           rv_project_name = rv_project_name)
   
   ### Select gridded data (optional)
   rv_data_names$grid <- select_data_server("select_grid",
                                            data_type = "grid",
                                            rv_project_name = rv_project_name)
-  
-  ##### TEST CODE #####
-  count <- reactiveVal(0)
-  
-  observeEvent(input$test_btn,{
-    new_count <- count() + 1
-    count(new_count)
-    cat(file=stderr(), "\n", new_count, "\n")
-    
-    output$display_main <- renderPrint(
-      str(rv_data_names$main())
-    )
-    
-    output$display_port <- renderPrint(
-      str(rv_data_names$port())
-    )
-    
-    output$display_aux <- renderPrint(
-      str(rv_data_names$aux())
-    )
-    
-    output$display_spat <- renderPrint(
-      str(rv_data_names$spat())
-    )
-    
-    output$display_grid <- renderPrint(
-      str(rv_data_names$grid())
-    )
-  })
-  #####################
 }

--- a/inst/ShinyFiles/MainApp/server.R
+++ b/inst/ShinyFiles/MainApp/server.R
@@ -45,21 +45,22 @@ server <- function(input, output, session) {
   rv_data_names$main <- select_data_server("select_main",
                                            data_type = "main",
                                            rv_project_name = rv_project_name)
-  
+
   ### Select port data (optional)
   rv_data_names$port <- select_data_server("select_port",
                                            data_type = "port",
                                            rv_project_name = rv_project_name)
-  
+
   ### Select aux data (optional)
   rv_data_names$aux <- select_data_server("select_aux",
                                           data_type = "aux",
                                           rv_project_name = rv_project_name)
-  
+
   ### Select spatial data
-  rv_data_names$spatial <- select_spatial_server("select_spatial", 
-                                                 rv_project_name = rv_project_name)
-  
+  rv_data_names$spatial <- select_data_server("select_spatial",
+                                              data_type = "spat",
+                                              rv_project_name = rv_project_name)
+
   ### Select gridded data (optional)
   rv_data_names$grid <- select_data_server("select_grid",
                                            data_type = "grid",

--- a/inst/ShinyFiles/MainApp/server.R
+++ b/inst/ShinyFiles/MainApp/server.R
@@ -45,22 +45,22 @@ server <- function(input, output, session) {
   rv_data_names$main <- select_data_server("select_main",
                                            data_type = "main",
                                            rv_project_name = rv_project_name)
-
+  
   ### Select port data (optional)
   rv_data_names$port <- select_data_server("select_port",
                                            data_type = "port",
                                            rv_project_name = rv_project_name)
-
+  
   ### Select aux data (optional)
   rv_data_names$aux <- select_data_server("select_aux",
                                           data_type = "aux",
                                           rv_project_name = rv_project_name)
-
+  
   ### Select spatial data
   rv_data_names$spatial <- select_data_server("select_spatial",
                                               data_type = "spat",
                                               rv_project_name = rv_project_name)
-
+  
   ### Select gridded data (optional)
   rv_data_names$grid <- select_data_server("select_grid",
                                            data_type = "grid",

--- a/inst/ShinyFiles/MainApp/server.R
+++ b/inst/ShinyFiles/MainApp/server.R
@@ -41,18 +41,27 @@ server <- function(input, output, session) {
   ### Select project name
   rv_project_name <- select_project_server("select_project", rv_folderpath = rv_folderpath)
   
-  ### Select primary data
-  rv_data_names$primary <- select_primary_server("select_primary", 
-                                                 rv_project_name = rv_project_name)
-  ### Select port data
-  rv_data_names$port <- select_port_server("select_port", 
+  ### Select main data
+  rv_data_names$main <- select_data_server("select_main",
+                                           data_type = "main",
                                            rv_project_name = rv_project_name)
+  
+  ### Select port data (optional)
+  rv_data_names$port <- select_data_server("select_port",
+                                           data_type = "port",
+                                           rv_project_name = rv_project_name)
+  
+  ### Select aux data (optional)
+  rv_data_names$aux <- select_data_server("select_aux",
+                                          data_type = "aux",
+                                          rv_project_name = rv_project_name)
   
   ### Select spatial data
   rv_data_names$spatial <- select_spatial_server("select_spatial", 
                                                  rv_project_name = rv_project_name)
   
   ### Select gridded data (optional)
-  rv_data_names$grid <- select_grid_server("select_grid", 
+  rv_data_names$grid <- select_data_server("select_grid",
+                                           data_type = "grid",
                                            rv_project_name = rv_project_name)
 }

--- a/inst/ShinyFiles/MainApp/ui.R
+++ b/inst/ShinyFiles/MainApp/ui.R
@@ -74,17 +74,17 @@ ui <- function(request){
                           bslib::card_body(
                             bslib::card(
                               bslib::card_body(
-                                select_data_ui("select_main", "main")  
+                                select_data_ui("select_main", data_type = "main")
                               )
                             ),
                             bslib::card(
                               bslib::card_body(
-                                select_port_ui("select_port")  
+                                select_data_ui("select_port", data_type = "port")
                               )
                             ),
                             bslib::card(
                               bslib::card_body(
-                                select_aux_ui("select_aux")
+                                select_data_ui("select_aux", data_type = "aux")
                               )
                             )
                           )
@@ -96,12 +96,12 @@ ui <- function(request){
                           bslib::card_body(
                             bslib::card(fill = FALSE,
                                         bslib::card_body(
-                                          select_spatial_ui("select_spatial")
+                                          select_data_ui("select_spatial", data_type = "spat")
                                         )
                             ), 
                             bslib::card(fill = FALSE,
                                         bslib::card_body(
-                                          select_grid_ui("select_grid")
+                                          select_data_ui("select_grid", data_type = "grid")
                                         )
                             )
                           )

--- a/inst/ShinyFiles/MainApp/ui.R
+++ b/inst/ShinyFiles/MainApp/ui.R
@@ -68,18 +68,23 @@ ui <- function(request){
             
             bslib::layout_column_wrap(
               width = 1/2,
-              ### Select primary data 
+              ### Select main data 
               bslib::card(fill = FALSE,
                           bslib::card_header("3. Primary data"),
                           bslib::card_body(
                             bslib::card(
                               bslib::card_body(
-                                select_primary_ui("select_primary")  
+                                select_data_ui("select_main", "main")  
                               )
                             ),
                             bslib::card(
                               bslib::card_body(
                                 select_port_ui("select_port")  
+                              )
+                            ),
+                            bslib::card(
+                              bslib::card_body(
+                                select_aux_ui("select_aux")
                               )
                             )
                           )

--- a/inst/ShinyFiles/MainApp/ui.R
+++ b/inst/ShinyFiles/MainApp/ui.R
@@ -47,6 +47,18 @@ ui <- function(request){
               fill = TRUE, 
               width = 400,
               
+              actionButton("test_btn", "TEST"),
+              p("Main: "),
+              verbatimTextOutput("display_main"),
+              p("Port: "),
+              verbatimTextOutput("display_port"),
+              p("Auxiliary: "),
+              verbatimTextOutput("display_aux"),
+              p("Spatial: "),
+              verbatimTextOutput("display_spat"),
+              p("Grid: "),
+              verbatimTextOutput("display_grid")
+              
             ),
             
             ### Change folder path

--- a/inst/ShinyFiles/MainApp/ui.R
+++ b/inst/ShinyFiles/MainApp/ui.R
@@ -47,18 +47,6 @@ ui <- function(request){
               fill = TRUE, 
               width = 400,
               
-              actionButton("test_btn", "TEST"),
-              p("Main: "),
-              verbatimTextOutput("display_main"),
-              p("Port: "),
-              verbatimTextOutput("display_port"),
-              p("Auxiliary: "),
-              verbatimTextOutput("display_aux"),
-              p("Spatial: "),
-              verbatimTextOutput("display_spat"),
-              p("Grid: "),
-              verbatimTextOutput("display_grid")
-              
             ),
             
             ### Change folder path


### PR DESCRIPTION
Created a general select data module (server and ui) for all data types (main, port, aux, spat, and grid). The new module server and ui take an input value for data type. I also had to create a reactive (rv_input_type) in the server module to track which input value should be returned. 

Let me know if I should add more comments/documentation, or need to update anything else.

Linked to #243 