### PR TITLE
Fsl qaqc datatable

### DIFF
--- a/inst/ShinyFiles/MainApp/modules/load_files_server.R
+++ b/inst/ShinyFiles/MainApp/modules/load_files_server.R
@@ -938,7 +938,9 @@ load_data_server <- function(id, rv_project_name, rv_data_names, parent_session)
     # Next button to move user to Select variables sub-tab
     observeEvent(input$load_data_next_btn, {
       bslib::nav_show(
-        id = "tabs", target = "select_variables", select = TRUE,
+        id = "tabs", 
+        target = "select_variables", 
+        select = TRUE,
         session = parent_session
       )
     })

--- a/inst/ShinyFiles/MainApp/modules/load_files_ui.R
+++ b/inst/ShinyFiles/MainApp/modules/load_files_ui.R
@@ -247,6 +247,7 @@ load_data_ui <- function(id){
         style = "color: green; display: none; font-size: 20px;",
         textOutput(ns("load_success_message_out"))
     ),
+    
     # next button to select variables tab
     actionButton(inputId = ns("load_data_next_btn"),
                  label = "Next",

--- a/inst/ShinyFiles/MainApp/modules/qaqc/preview_data_module.R
+++ b/inst/ShinyFiles/MainApp/modules/qaqc/preview_data_module.R
@@ -1,0 +1,68 @@
+# =================================================================================================
+# File: preview_data_module.R
+# Description: 
+#
+# Authors: Paul Carvalho, Anna Abelman
+# Date created: 8/4/2025
+# Dependencies: 
+# Notes: 
+# =================================================================================================
+
+# Load libraries
+library(DT)
+
+# 
+preview_data_server <- function(id, rv_project_name, rv_data){
+  moduleServer(id, function(input, output, session){
+    ns <- session$ns
+    
+    observe({
+      data_list <- reactiveValuesToList(rv_data)
+      
+      if (is.null(data_list) || length(data_list) == 0) {
+        updateSelectInput(session, "select_data", choices = character(0)) # Clear choices
+        return()
+      }
+      
+      df_names <- names(data_list)[sapply(data_list, is.data.frame)]
+      
+      cat("\n", str(df_names), "\n")
+      
+      updateSelectInput(session, "select_data", choices = df_names)
+    })
+    
+    output$preview_datatable <- DT::renderDT({
+      req(input$select_data)
+      
+      df_to_display <- rv_data[[input$select_data]]
+      
+      req(df_to_display)
+      
+      DT::datatable(
+        df_to_display,
+        rownames = FALSE,
+        filter = "top",
+        options = list(
+          scrollX = TRUE,
+          pageLength = 15
+        )
+      )
+    })
+    
+  })
+}
+
+#
+preview_data_ui <- function(id){
+  ns <- NS(id)
+  
+  tagList(
+    selectInput(ns("select_data"),
+                label = "Select data to view:",
+                choices = NULL),
+    
+    DT::DTOutput(ns("preview_datatable"))
+  )
+  
+  
+}

--- a/inst/ShinyFiles/MainApp/modules/qaqc/preview_data_module.R
+++ b/inst/ShinyFiles/MainApp/modules/qaqc/preview_data_module.R
@@ -26,8 +26,6 @@ preview_data_server <- function(id, rv_project_name, rv_data){
       
       df_names <- names(data_list)[sapply(data_list, is.data.frame)]
       
-      cat("\n", str(df_names), "\n")
-      
       updateSelectInput(session, "select_data", choices = df_names)
     })
     

--- a/inst/ShinyFiles/MainApp/modules/qaqc/preview_data_module.R
+++ b/inst/ShinyFiles/MainApp/modules/qaqc/preview_data_module.R
@@ -1,39 +1,57 @@
 # =================================================================================================
 # File: preview_data_module.R
-# Description: 
+# Description: This module displays an interactive table to view loaded data tables. It includes
+#              a dropdown menu to select a table to view.
 #
 # Authors: Paul Carvalho, Anna Abelman
 # Date created: 8/4/2025
-# Dependencies: 
-# Notes: 
+# Dependencies: shiny, DT
+# Notes: This module is used within qaqc_module.R
 # =================================================================================================
 
 # Load libraries
 library(DT)
 
-# 
+#' preview_data_server
+#'
+#' @description Defines the server-side logic for the data preview module. It populates
+#' a dropdown with available data frames and renders the selected data frame in an
+#  interactive DT::datatable.
+#'
+#' @param id A character string that is unique to this module instance.
+#' @param rv_project_name A reactive value containing the current project name.
+#' @param rv_data A reactiveValues object containing the list of data frames to be displayed.
+#'
+#' @return This module does not return a value.
 preview_data_server <- function(id, rv_project_name, rv_data){
   moduleServer(id, function(input, output, session){
     ns <- session$ns
     
+    # Observe to dynamically update choice in the preview data table dropdown.
     observe({
       data_list <- reactiveValuesToList(rv_data)
       
+      # If the data list is empty or NULL, clear the choices and exit.
       if (is.null(data_list) || length(data_list) == 0) {
         updateSelectInput(session, "select_data", choices = character(0)) # Clear choices
         return()
       }
       
+      # Filter the list to get only the names of objects that are data frames
       df_names <- names(data_list)[sapply(data_list, is.data.frame)]
       
+      # Update input options
       updateSelectInput(session, "select_data", choices = df_names)
     })
     
+    # Render interactive data table.
     output$preview_datatable <- DT::renderDT({
       req(input$select_data)
       
+      # Get the df to display based on input
       df_to_display <- rv_data[[input$select_data]]
       
+      # Require input from user
       req(df_to_display)
       
       DT::datatable(
@@ -46,11 +64,17 @@ preview_data_server <- function(id, rv_project_name, rv_data){
         )
       )
     })
-    
   })
 }
 
-#
+#' preview_data_ui
+#'
+#' @description Creates the user interface for the data preview module. This includes
+#' a dropdown for data selection and a placeholder for the data table.
+#'
+#' @param id A character string that is unique to this module instance.
+#'
+#' @return A tagList containing the UI elements for the preview data module.
 preview_data_ui <- function(id){
   ns <- NS(id)
   

--- a/inst/ShinyFiles/MainApp/modules/qaqc_module.R
+++ b/inst/ShinyFiles/MainApp/modules/qaqc_module.R
@@ -1,0 +1,28 @@
+# =================================================================================================
+# File: qaqc_module.R
+# Description: 
+#
+# Authors: Paul Carvalho, Anna Abelman
+# Date created: 8/4/2025
+# Dependencies: 
+# Notes: 
+# =================================================================================================
+
+# Source module scripts ---------------------------------------------------------------------------
+source("modules/qaqc/preview_data_module.R", local = TRUE) # Preview data in table format
+
+# 
+qaqc_server <- function(id, rv_project_name, rv_data){
+  moduleServer(id, function(input, output, session){
+    ns <- session$ns
+    
+    preview_data_server("preview_data", rv_project_name, rv_data)
+  })
+}
+
+#
+qaqc_ui <- function(id){
+  ns <- NS(id)
+  
+  preview_data_ui(ns("preview_data"))
+}

--- a/inst/ShinyFiles/MainApp/modules/qaqc_module.R
+++ b/inst/ShinyFiles/MainApp/modules/qaqc_module.R
@@ -11,12 +11,29 @@
 # Source module scripts ---------------------------------------------------------------------------
 source("modules/qaqc/preview_data_module.R", local = TRUE) # Preview data in table format
 
+# UI for the sidebar controls in the QAQC tab
+qaqc_sidebar_ui <- function(id) {
+  ns <- NS(id)
+  tagList(
+    radioButtons(ns("qaqc_options"), 
+                 "Data quality checks:",
+                 choices = c("Preview data" = "preview",
+                             "Simple message" = "message"),
+                 selected = "preview")
+  )
+}
+
+
 # 
 qaqc_server <- function(id, rv_project_name, rv_data){
   moduleServer(id, function(input, output, session){
     ns <- session$ns
     
     preview_data_server("preview_data", rv_project_name, rv_data)
+    
+    output$message <- renderText({
+      "This is a simple message displayed when the 'Simple message' radio button is selected."
+    })
   })
 }
 
@@ -24,5 +41,22 @@ qaqc_server <- function(id, rv_project_name, rv_data){
 qaqc_ui <- function(id){
   ns <- NS(id)
   
-  preview_data_ui(ns("preview_data"))
+  tagList(
+    # Conditionally display the preview data UI
+    conditionalPanel(
+      condition = "input.qaqc_options == 'preview'",
+      ns = ns,
+      preview_data_ui(ns("preview_data"))
+    ),
+    
+    # Conditionally display the simple message
+    conditionalPanel(
+      condition = "input.qaqc_options == 'message'",
+      ns = ns,
+      h4("A Simple Message"),
+      wellPanel(
+        textOutput(ns("message"))
+      )
+    )
+  )
 }

--- a/inst/ShinyFiles/MainApp/modules/qaqc_module.R
+++ b/inst/ShinyFiles/MainApp/modules/qaqc_module.R
@@ -1,43 +1,63 @@
 # =================================================================================================
 # File: qaqc_module.R
-# Description: 
+# Description: This module defines the UI and server logic for the QAQC tab. It allows the user to 
+#              preview data in tables, run various quality checks, and visualize data spatially.
 #
 # Authors: Paul Carvalho, Anna Abelman
 # Date created: 8/4/2025
-# Dependencies: 
-# Notes: 
+# Dependencies: shiny, DT, preview_data_module.R
+# Notes: This module sources other qaqc modules saved in the /modules/qaqc/ folder in FishSET.
 # =================================================================================================
 
 # Source module scripts ---------------------------------------------------------------------------
 source("modules/qaqc/preview_data_module.R", local = TRUE) # Preview data in table format
 
-# UI for the sidebar controls in the QAQC tab
+#' qaqc_server
+#'
+#' @description Defines the server-side logic for the QAQC tab. It handles the
+#' rendering of the different UI components based on the user's selection in the sidebar.
+#'
+#' @param id A character string that is unique to this module instance.
+#' @param rv_project_name A reactive value containing the current project name.
+#' @param rv_data A reactiveValues object containing the loaded data frames.
+#'
+#' @return This module does not return a value.
+qaqc_server <- function(id, rv_project_name, rv_data){
+  moduleServer(id, function(input, output, session){
+    ns <- session$ns
+    
+    # Preview data tables
+    preview_data_server("preview_data", rv_project_name, rv_data)
+    
+  })
+}
+
+#' qaqc_sidebar_ui
+#'
+#' @description Creates the sidebar UI for the QAQC tab. This includes radio buttons
+#' that allow the user to select between quality check functions.
+#'
+#' @param id A character string that is unique to this module instance.
+#'
+#' @return A tagList containing the sidebar UI elements.
 qaqc_sidebar_ui <- function(id) {
   ns <- NS(id)
   tagList(
     radioButtons(ns("qaqc_options"), 
                  "Data quality checks:",
-                 choices = c("Preview data" = "preview",
-                             "Simple message" = "message"),
+                 choices = c("Preview data" = "preview"),
                  selected = "preview")
   )
 }
 
-
-# 
-qaqc_server <- function(id, rv_project_name, rv_data){
-  moduleServer(id, function(input, output, session){
-    ns <- session$ns
-    
-    preview_data_server("preview_data", rv_project_name, rv_data)
-    
-    output$message <- renderText({
-      "This is a simple message displayed when the 'Simple message' radio button is selected."
-    })
-  })
-}
-
-#
+#' qaqc_ui
+#'
+#' @description Creates the main panel UI for the QAQC tab. It uses conditionalPanels
+#' to show or hide content based on the radio button selection in the sidebar for quality checks.
+#'
+#' @param id A character string that is unique to this module instance.
+#'
+#' @return A tagList containing the main panel UI elements.
 qaqc_ui <- function(id){
   ns <- NS(id)
   
@@ -47,16 +67,6 @@ qaqc_ui <- function(id){
       condition = "input.qaqc_options == 'preview'",
       ns = ns,
       preview_data_ui(ns("preview_data"))
-    ),
-    
-    # Conditionally display the simple message
-    conditionalPanel(
-      condition = "input.qaqc_options == 'message'",
-      ns = ns,
-      h4("A Simple Message"),
-      wellPanel(
-        textOutput(ns("message"))
-      )
     )
   )
 }

--- a/inst/ShinyFiles/MainApp/modules/select_variables_server.R
+++ b/inst/ShinyFiles/MainApp/modules/select_variables_server.R
@@ -561,7 +561,7 @@ save_var_server <- function(id, rv_project_name, rv_data, parent_session){
         shinyjs::hide("save_var_spinner_container")
       })
       
-      # Next button to move user to Select variables sub-tab
+      # Next button to move user to quality checks sub-tab
       observeEvent(input$select_var_next_btn, {
         bslib::nav_show(
           id = "tabs", 

--- a/inst/ShinyFiles/MainApp/modules/select_variables_server.R
+++ b/inst/ShinyFiles/MainApp/modules/select_variables_server.R
@@ -468,7 +468,7 @@ create_nominal_id_inputs_server <- function(id, rv_project_name, rv_data,
 ## Save variables to project folder ----------------------------------------------------------
 ## Description: Users can save variables from all data tables so they can be used in future 
 ##              sessions
-save_var_server <- function(id, rv_project_name, rv_data){
+save_var_server <- function(id, rv_project_name, rv_data, parent_session){
   moduleServer(
     id,
     function(input, output, session){
@@ -559,6 +559,16 @@ save_var_server <- function(id, rv_project_name, rv_data){
         
         # Hide local spinner
         shinyjs::hide("save_var_spinner_container")
+      })
+      
+      # Next button to move user to Select variables sub-tab
+      observeEvent(input$select_var_next_btn, {
+        bslib::nav_show(
+          id = "tabs", 
+          target = "quality_checks", 
+          select = TRUE,
+          session = parent_session
+        )
       })
     }
   )

--- a/inst/ShinyFiles/MainApp/modules/select_variables_ui.R
+++ b/inst/ShinyFiles/MainApp/modules/select_variables_ui.R
@@ -305,7 +305,15 @@ save_var_ui <- function(id){
           style = "color: green; display: none; font-size: 20px;",
           textOutput(ns("var_success_message_out"))
       )
-    )
+    ),
+    
+    # next button to select variables tab
+    actionButton(inputId = ns("select_var_next_btn"),
+                 label = "Next",
+                 width = "15%",
+                 style = "float:right",
+                 icon = icon(name="circle-chevron-right", 
+                             lib="font-awesome"))
   )
 }
 

--- a/inst/ShinyFiles/MainApp/modules/select_variables_ui.R
+++ b/inst/ShinyFiles/MainApp/modules/select_variables_ui.R
@@ -307,7 +307,7 @@ save_var_ui <- function(id){
       )
     ),
     
-    # next button to select variables tab
+    # Next button to move to quality checks tab
     actionButton(inputId = ns("select_var_next_btn"),
                  label = "Next",
                  width = "15%",

--- a/inst/ShinyFiles/MainApp/server.R
+++ b/inst/ShinyFiles/MainApp/server.R
@@ -114,9 +114,19 @@ server <- function(input, output, session) {
   #### Save all selected variables to project data folder 
   save_var_server("saving_all_variables", 
                   rv_project_name = rv_project_name,
-                  rv_data = rv_data)
+                  rv_data = rv_data,
+                  parent_session = session)
   
   # QAQC ------------------------------------------------------------------------------------------
   ## Quality checks -------------------------------------------------------------------------------
+  checklist_server("quality_check_checklist", rv_project_name, rv_data)
+  
+  other_actions_server("quality_check_actions",
+                       values = list(project_name = rv_project_name,
+                                     data = rv_data),
+                       rv_project_name = rv_project_name,
+                       rv_data_load_error = reactive(rv_data_load_error()),
+                       current_tab = reactive(input$tabs))
+  
   qaqc_server("qaqc_checks", rv_project_name, rv_data)
 }

--- a/inst/ShinyFiles/MainApp/server.R
+++ b/inst/ShinyFiles/MainApp/server.R
@@ -19,6 +19,7 @@
 source("modules/load_files_server.R", local = TRUE) # Upload data - load files subtab
 source("modules/other_actions_server.R", local = TRUE) # Other actions in sidebar 
 source("modules/select_variables_server.R", local = TRUE) # Other actions in sidebar 
+source("modules/qaqc_module.R", local = TRUE)
 
 # Server settings ---------------------------------------------------------------------------------
 options(shiny.maxRequestSize = 8000*1024^2) # set the max file upload size
@@ -114,4 +115,8 @@ server <- function(input, output, session) {
   save_var_server("saving_all_variables", 
                   rv_project_name = rv_project_name,
                   rv_data = rv_data)
+  
+  # QAQC ------------------------------------------------------------------------------------------
+  ## Quality checks -------------------------------------------------------------------------------
+  qaqc_server("qaqc_checks", rv_project_name, rv_data)
 }

--- a/inst/ShinyFiles/MainApp/server.R
+++ b/inst/ShinyFiles/MainApp/server.R
@@ -119,6 +119,7 @@ server <- function(input, output, session) {
   
   # QAQC ------------------------------------------------------------------------------------------
   ## Quality checks -------------------------------------------------------------------------------
+  ### Sidebar
   checklist_server("quality_check_checklist", rv_project_name, rv_data)
   
   other_actions_server("quality_check_actions",
@@ -128,5 +129,6 @@ server <- function(input, output, session) {
                        rv_data_load_error = reactive(rv_data_load_error()),
                        current_tab = reactive(input$tabs))
   
+  ### Main panel
   qaqc_server("qaqc_checks", rv_project_name, rv_data)
 }

--- a/inst/ShinyFiles/MainApp/ui.R
+++ b/inst/ShinyFiles/MainApp/ui.R
@@ -18,6 +18,7 @@ source("modules/spinner.R", local = TRUE) # Reusable spinner
 source("modules/load_files_ui.R", local = TRUE) # Upload data - load files subtab
 source("modules/other_actions_ui.R", local = TRUE) # Other actions in sidebar 
 source("modules/select_variables_ui.R", local = TRUE) # Other actions in sidebar 
+source("modules/qaqc_module.R", local = TRUE)
 
 # UI function definition
 ui <- function(request){
@@ -107,6 +108,20 @@ ui <- function(request){
             )
           )
         )
+      )
+    ),
+    
+    # QAQC ----------------------------------------------------------------------------------------
+    bslib::nav_menu(
+      title = "QAQC",
+      
+      ## Quality checks subtab --------------------------------------------------------------------
+      bslib::nav_panel(
+        title = "Quality checks", 
+        id = "quality_checks",
+        value = "quality_checks",
+        
+        qaqc_ui("qaqc_checks")
       )
     )
   )

--- a/inst/ShinyFiles/MainApp/ui.R
+++ b/inst/ShinyFiles/MainApp/ui.R
@@ -85,8 +85,8 @@ ui <- function(request){
       ## Select variables subtab ------------------------------------------------------------------
       bslib::nav_panel(
         title = "Select variables", 
-        value = "select_variables",
         id = "select_variables",
+        value = "select_variables",
         bslib::page_fillable(
           bslib::layout_sidebar(
             fillable = TRUE, 
@@ -117,11 +117,31 @@ ui <- function(request){
       
       ## Quality checks subtab --------------------------------------------------------------------
       bslib::nav_panel(
-        title = "Quality checks", 
+        title = "Data quality checks", 
         id = "quality_checks",
         value = "quality_checks",
+        bslib::page_fillable(
+          bslib::layout_sidebar(
+            fillable = TRUE,
+            fill = TRUE,
+            
+            ### Sidebar
+            sidebar = bslib::sidebar( 
+              fillable = TRUE, 
+              fill = TRUE, 
+              width = 400,
+              
+              checklist_ui("quality_check_checklist"),
+              hr(),
+              qaqc_sidebar_ui("qaqc_checks"),
+              other_actions_ui("quality_check_actions")
+            ),
+            
+            ### Main panel
+            qaqc_ui("qaqc_checks")    
+          )
+        )
         
-        qaqc_ui("qaqc_checks")
       )
     )
   )


### PR DESCRIPTION
Added next button to select variable tab and added preview data option for qaqc tab. 

Note: Trying out a different format for modules file structure. The qaqc_module.R contains the overall server and ui logic for the qaqc tab, and each data quality check will be saved as a separate module script in the /modules/qaqc/ folder. The main reason for making this change here was to have each data quality check as a separate file and have the server and ui logic in the same script. 

Linked to #297 